### PR TITLE
extend maximum conda prefix length

### DIFF
--- a/easy-deploy-script/easy-deploy-viral-ngs.sh
+++ b/easy-deploy-script/easy-deploy-viral-ngs.sh
@@ -23,7 +23,7 @@ SCRIPT_DIRNAME="$(dirname "$SOURCE")"
 SCRIPTPATH="$(cd -P "$(echo $SCRIPT_DIRNAME)" &> /dev/null && pwd)"
 SCRIPT="$SCRIPTPATH/$(basename "$SCRIPT")"
 
-CONDA_PREFIX_LENGTH_LIMIT=80
+CONDA_PREFIX_LENGTH_LIMIT=253
 
 CONTAINING_DIR="viral-ngs-etc"
 VIRAL_NGS_DIR="viral-ngs"


### PR DESCRIPTION
See: https://github.com/conda/conda-build/pull/877
The prefix is now seemingly 255 characters.