### PR TITLE
Upgrade to Ubuntu 16.04 and some updates

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,11 @@
-FROM ubuntu:15.04
+# This base image is equivalent to Ubuntu 16.04 but has better defaults
+# and fixes numerous problems with the stock Ubuntu images.
+# read more about it here: https://github.com/phusion/baseimage-docker
+FROM phusion/baseimage:0.9.19
+
+# Use baseimage-docker's init system.
+CMD ["/sbin/my_init"]
+
 MAINTAINER Chris Tomkins-Tinch <tomkinsc@broadinstitute.org>
 
 # to build:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,10 +23,14 @@ MAINTAINER Chris Tomkins-Tinch <tomkinsc@broadinstitute.org>
 
 ARG VIRAL_NGS_VERSION
 
+# Silence some warnings about Readline. Checkout more over here:
+# https://github.com/phusion/baseimage-docker/issues/58
+ENV DEBIAN_FRONTEND noninteractive
+
 # System packages 
-RUN apt-get update && apt-get upgrade
-RUN apt-get install -y curl bzip2 build-essential python wget 
-RUN apt-get install -y less nano
+RUN apt-get update && \
+apt-get install -y curl bzip2 build-essential python wget less nano libterm-readline-gnu-perl &&\
+apt-get upgrade -y
 
 # Set the locale
 RUN locale-gen en_US.UTF-8
@@ -58,20 +62,21 @@ RUN ln -s /user-data /home/$DOCKER_USER/data
 #RUN curl -LO https://raw.githubusercontent.com/broadinstitute/viral-ngs-deploy/master/easy-deploy-script/easy-deploy-viral-ngs.sh
 USER root
 ADD ./easy-deploy-script/easy-deploy-viral-ngs.sh /home/$DOCKER_USER/easy-deploy-viral-ngs.sh
-RUN chmod +x ./easy-deploy-viral-ngs.sh
-RUN chown $DOCKER_USER:$DOCKER_USER ./easy-deploy-viral-ngs.sh
+RUN chmod +x ./easy-deploy-viral-ngs.sh && \
+    chown $DOCKER_USER:$DOCKER_USER ./easy-deploy-viral-ngs.sh
 USER $DOCKER_USER
 ENV VIRAL_NGS_VERSION $VIRAL_NGS_VERSION
+
 RUN echo "Running easy install with viral-ngs version $VIRAL_NGS_VERSION"
-RUN bash -c 'echo $(if [ "$VIRAL_NGS_VERSION" == "" ]; then echo "./easy-deploy-viral-ngs.sh setup"; else echo "./easy-deploy-viral-ngs.sh setup --viral-ngs-version $VIRAL_NGS_VERSION" ; fi)'
 RUN bash -c '$(if [ "$VIRAL_NGS_VERSION" == "" ]; then echo "./easy-deploy-viral-ngs.sh setup"; else echo "./easy-deploy-viral-ngs.sh setup --viral-ngs-version $VIRAL_NGS_VERSION" ; fi)'
 
 # add a wrapper script to load the viral-ngs environment via the easy-deploy script
 # and then run any commands desired
 USER root
 ADD ./env_wrapper.sh /home/$DOCKER_USER/env_wrapper.sh
-RUN chmod +x ./env_wrapper.sh
-RUN chown $DOCKER_USER:$DOCKER_USER ./env_wrapper.sh
+RUN chmod +x ./env_wrapper.sh && chown $DOCKER_USER:$DOCKER_USER ./env_wrapper.sh
 USER $DOCKER_USER
+
+ENV DEBIAN_FRONTEND teletype
 
 ENTRYPOINT ["./env_wrapper.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,6 +62,7 @@ USER $DOCKER_USER
 ENV VIRAL_NGS_VERSION $VIRAL_NGS_VERSION
 
 RUN echo "Running easy install with viral-ngs version $VIRAL_NGS_VERSION"
+RUN bash -c 'echo $(if [ "$VIRAL_NGS_VERSION" == "" ]; then echo "./easy-deploy-viral-ngs.sh setup"; else echo "./easy-deploy-viral-ngs.sh setup --viral-ngs-version $VIRAL_NGS_VERSION" ; fi)'
 RUN bash -c '$(if [ "$VIRAL_NGS_VERSION" == "" ]; then echo "./easy-deploy-viral-ngs.sh setup"; else echo "./easy-deploy-viral-ngs.sh setup --viral-ngs-version $VIRAL_NGS_VERSION" ; fi)'
 
 # add a wrapper script to load the viral-ngs environment via the easy-deploy script

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,4 @@
-# This base image is equivalent to Ubuntu 16.04 but has better defaults
-# and fixes numerous problems with the stock Ubuntu images.
-# read more about it here: https://github.com/phusion/baseimage-docker
-FROM phusion/baseimage:0.9.19
-
-# Use baseimage-docker's init system.
-CMD ["/sbin/my_init"]
+FROM ubuntu:16.04
 
 MAINTAINER Chris Tomkins-Tinch <tomkinsc@broadinstitute.org>
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -22,7 +22,20 @@ By default, the pipeline will install a single-threaded version of [Novoalign](h
   ```
   tar -czh . | docker build --rm --build-arg VIRAL_NGS_VERSION=1.15.0 -
   ```
-  Note that the version of viral-ngs specified must exist in one of the channels specified in the easy-install script.
+  Note that the version of viral-ngs specified must exist in one of the channels specified in the easy-install script. As of March 2017, check available version at [broad-viral](https://anaconda.org/broad-viral/viral-ngs/files) channel.  Otherwise, build may fail with an error like this:
+
+  ```shell
+ PackageNotFoundError: Package not found: '' Package missing in current linux-64 channels:
+  - viral-ngs 1.15.0*
+
+You can search for packages on anaconda.org with
+
+    anaconda search -t conda viral-ngs
+
+You may need to install the anaconda-client command line client with
+
+    conda install anaconda-client
+  ```
   
 ### To run
 Download licensed copies of GATK and Novoalign to the host machine (for Linux-64), and run:

--- a/easy-deploy-script/easy-deploy-viral-ngs.sh
+++ b/easy-deploy-script/easy-deploy-viral-ngs.sh
@@ -292,9 +292,9 @@ function check_viral_ngs_version(){
     # so, after a call to "activate_env"
     if [ -z "$SKIP_VERSION_CHECK" ]; then
         echo "Checking viral-ngs version..."
-        CURRENT_VER="$(conda list --no-pip viral-ngs | grep viral-ngs | grep -v packages | awk -F" " '{print $2}')"
+        CURRENT_VER="$(conda list --no-pip viral-ngs | grep viral-ngs | grep -v packages | awk -F' ' '{print $2}')"
         # perhaps a better way...
-        AVAILABLE_VER="$(conda search --override-channels -f -c broad-viral -c r -c bioconda -c conda-forge -c defaults --override-channels viral-ngs --json | grep version | tail -n 1 | awk -F" " '{print $2}' | perl -lape 's/[",]+//g')"
+        AVAILABLE_VER="$(conda search --override-channels -f -c broad-viral -c r -c bioconda -c conda-forge -c defaults --override-channels viral-ngs --json | grep version | tail -n 1 | awk -F' ' '{print $2}' | perl -lape 's/[\",]+//g')"
         if [ "$CURRENT_VER" != "$AVAILABLE_VER" ]; then
             echo ""
             echo "============================================================================================================"


### PR DESCRIPTION
I upgraded to Ubuntu 16.04 because Ubuntu 15.04 is not available for download anymore from the default Docker hub. 

Some other updates are explained in the commit messages. 

Docker build ran successfully when running the following command inside `docker` directory, even though I haven't check with GATK and Novoalign stuffs: 
`tar -czh . | docker build --rm --build-arg VIRAL_NGS_VERSION=1.15.4 -`

I think there is still room for improvement on the Dockerfile so that we can omit the `--rm` argument when building, thereby reduce build time. Currently the steps where docker download and install `conda` packages are the longest ones.