### PR TITLE
add gcloud binaries to docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,12 +24,19 @@ ENV DEBIAN_FRONTEND noninteractive
 ##############################
 # System packages and locale
 ##############################
+# removing /var/lib/apt/lists/* frees some space
 RUN apt-get update \
-    && apt-get install -y -qq --no-install-recommends ca-certificates wget curl bzip2 python less nano vim locales \
+    && apt-get install -y -qq --no-install-recommends ca-certificates wget curl bzip2 python less nano vim locales gcc python-dev python-setuptools \
     && apt-get upgrade -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && locale-gen en_US.UTF-8
+
+# Google Cloud SDK to support GS storage
+RUN curl -sSL https://sdk.cloud.google.com | bash -s - "--install-dir=/opt"
+ENV PATH $PATH:/opt/google-cloud-sdk/bin
+RUN easy_install -Uq pip
+RUN pip install -Uq crcmod
 
 # Set default locale to en_US.UTF-8
 ENV LANG="en_US.UTF-8" LANGUAGE="en_US:en" LC_ALL="en_US.UTF-8"

--- a/travis/tests-unit.sh
+++ b/travis/tests-unit.sh
@@ -39,16 +39,26 @@ if [ "$TEST_DOCKER" == "true" ]; then
     if [ -z "$UPSTREAM_TAG" ]; then
         # build the docker image, and try to run it
         tar -czh . | docker build --rm - | tee >(grep "Successfully built" | perl -lape 's/^Successfully built ([a-f0-9]{12})$/$1/g' > build_id) | grep ".*" && build_image=$(head -n 1 build_id) && rm build_id
-        echo "build_image: $build_image"
-        docker run --rm $build_image illumina.py
+
+        if [[ ! -z $build_image ]]; then
+            echo "build_image: $build_image"
+            docker run --rm $build_image illumina.py
+        else
+            echo "Docker build failed."
+        fi
     # if this was triggered by the upstream repo, build, tag, and push to Docker Hub
     else
         export REPO=broadinstitute/viral-ngs
         export TAG=$(if [ "$UPSTREAM_TAG" == "master" ]; then echo "latest"; else echo "$UPSTREAM_TAG" ; fi)
         export VIRAL_NGS_VERSION=$(echo "$UPSTREAM_TAG" | perl -lape 's/^v(.*)/$1/g') # strip 'v' prefix
         tar -czh . | docker build --build-arg VIRAL_NGS_VERSION=$VIRAL_NGS_VERSION --rm -t "$REPO:$VIRAL_NGS_VERSION" - | tee >(grep "Successfully built" | perl -lape 's/^Successfully built ([a-f0-9]{12})$/$1/g' > build_id) | grep ".*" && build_image=$(head -n 1 build_id) && rm build_id
-        echo "build_image: $build_image"
-        docker run --rm $build_image illumina.py && docker login -u "$DOCKER_USER" -p "$DOCKER_PASS" && docker push "$REPO:$VIRAL_NGS_VERSION"
+
+        if [[ ! -z $build_image ]]; then
+            echo "build_image: $build_image"
+            docker run --rm $build_image illumina.py && docker login -u "$DOCKER_USER" -p "$DOCKER_PASS" && docker push "$REPO:$VIRAL_NGS_VERSION"
+        else
+            echo "Docker build failed."
+        fi
     fi
 fi
 


### PR DESCRIPTION
The gcloud binaries are needed for easy access to `gs://` objects, especially when the viral-ngs Docker image is executed on GCE via [dsub](https://github.com/googlegenomics/dsub).