### PR TITLE
thin Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,21 +22,21 @@ ARG VIRAL_NGS_VERSION
 ENV DEBIAN_FRONTEND noninteractive
 
 ##############################
-# System packages and locale
+# System packages, Google Cloud SDK, and locale
 ##############################
 # removing /var/lib/apt/lists/* frees some space
+# crcmod needed for Google Cloud SDK
+# 
 RUN apt-get update \
     && apt-get install -y -qq --no-install-recommends ca-certificates wget rsync curl bzip2 python less nano vim locales gcc python-dev python-setuptools \
     && apt-get upgrade -y \
+    && curl -sSL https://sdk.cloud.google.com | bash -s - "--install-dir=/opt" \
+    && easy_install -Uq pip \
+    && pip install -Uq crcmod \
+    && apt-get remove -y -qq gcc python-dev python-setuptools \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && locale-gen en_US.UTF-8
-
-# Google Cloud SDK to support GS storage
-RUN curl -sSL https://sdk.cloud.google.com | bash -s - "--install-dir=/opt"
-ENV PATH $PATH:/opt/google-cloud-sdk/bin
-RUN easy_install -Uq pip
-RUN pip install -Uq crcmod
 
 # Set default locale to en_US.UTF-8
 ENV LANG="en_US.UTF-8" LANGUAGE="en_US:en" LC_ALL="en_US.UTF-8"

--- a/easy-deploy-script/easy-deploy-viral-ngs.sh
+++ b/easy-deploy-script/easy-deploy-viral-ngs.sh
@@ -191,7 +191,6 @@ function install_miniconda(){
     if [ -d "$MINICONDA_PATH/bin" ]; then
         prepend_miniconda
         conda install -q -y -c defaults conda #==4.0.10
-        conda install -q -y -c defaults conda-build #==1.7.1
     else
         echo "It looks like the Miniconda installation failed"
         if [[ $sourced -eq 0 ]]; then
@@ -518,6 +517,8 @@ else
             else
                 echo "$VIRAL_CONDA_ENV_PATH/ already exists. Skipping conda env setup."
             fi
+
+            conda clean -y --all
 
             activate_env
 


### PR DESCRIPTION
These changes merge operations in the Dockerfile to a common layer, and remove unneeded artifacts. The easy-install script has also been changed to perform a `conda clean` as part of the setup process. Together, these changes trim ~1GB from the (uncompressed) Docker image for the current version of viral-ngs, 1.17.1.