### PR TITLE
easy-dsub.sh s/wget/curl/ in some scenarios

### DIFF
--- a/easy-dsub/easy-dsub.sh
+++ b/easy-dsub/easy-dsub.sh
@@ -193,9 +193,11 @@ function updateSelf() {
   # Download new version
   echo -n "Downloading latest version..."
   if ! wget --quiet --output-document="$SCRIPT.tmp" "$1" ; then
-    echo "Error while trying to wget new version!"
-    echo "File requested: $SELF_UPDATE_URL"
-    exit 1
+    if ! curl -s "$1" -o "$SCRIPT.tmp" ; then
+      echo "Error while trying to wget new version!"
+      echo "File requested: $SELF_UPDATE_URL"
+      exit 1
+    fi
   fi
   echo "done."
 
@@ -356,7 +358,7 @@ case $? in
             echo "NUM_CORES is: $NUM_CORES"
             echo "DISK_SIZE is: $DISK_SIZE"
 
-            latest_viral_ngs="$(wget -q https://registry.hub.docker.com/v1/repositories/broadinstitute/viral-ngs/tags -O -  | sed -e 's/[][]//g' -e 's/\"//g' -e 's/ //g' | tr '}' '\n'  | awk -F: '{print $3}' | grep '.' | tail -n 1)"
+            latest_viral_ngs="$(curl -s https://registry.hub.docker.com/v1/repositories/broadinstitute/viral-ngs/tags | sed -e 's/[][]//g' -e 's/\"//g' -e 's/ //g' | tr '}' '\n'  | awk -F: '{print $3}' | grep '.' | tail -n 1)"
             echo "Using viral-ngs version $latest_viral_ngs"
             echo "Called locally; submitting job via dsub"
 

--- a/easy-dsub/easy-dsub.sh
+++ b/easy-dsub/easy-dsub.sh
@@ -111,10 +111,11 @@ function install_and_prepend_miniconda(){
 
         if [[ "$(python -c 'import os; print(os.uname()[0])')" == "Darwin" ]]; then
             miniconda_url=https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh
+            curl -s $miniconda_url -o "$INSTALL_PATH/Miniconda2-latest-x86_64.sh"
         else
             miniconda_url=https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh
+            wget -q $miniconda_url -O "$INSTALL_PATH/Miniconda2-latest-x86_64.sh"
         fi
-        wget -q $miniconda_url -O "$INSTALL_PATH/Miniconda2-latest-x86_64.sh"
         chmod +x "$INSTALL_PATH/Miniconda2-latest-x86_64.sh"
         "$INSTALL_PATH/Miniconda2-latest-x86_64.sh" -b -f -p "$MINICONDA_PATH"
 


### PR DESCRIPTION
Partly to allow the easy-dsub.sh script to work on out-of-the-box MacOSX setups, this PR switches a few invocations of wget to curl. New behavior:

1. The conda install is os-specific (wget for linux, curl for osx)
2. The latest-docker-version grabber is now curl (since the google-cloud-sdk appears to install curl in our conda environment)
3. The self-updater tries both, and fails if neither works.
